### PR TITLE
esmf: update home page URL in Portfile

### DIFF
--- a/science/esmf/Portfile
+++ b/science/esmf/Portfile
@@ -22,7 +22,7 @@ description         software for building and coupling weather, climate, and rel
 long_description    The ESMF defines an architecture for composing complex, coupled \
                     modeling systems and includes data structures \
                     and utilities for developing individual models.
-homepage            https://www.earthsystemcog.org/projects/esmf/
+homepage            http://www.earthsystemmodeling.org
 github.tarball_from archive
 
 checksums           rmd160  59ded8c9e5db842fe7812c58ae19df98cb4bd9dd \


### PR DESCRIPTION
Update ESMF home page URL in portfile.
* Portfile change only.
* Did not change or look for any internal URL's in code or docs.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
(Not applicable)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->