### PR TITLE
WIP: djvulibre: remove unused librsvg dependency

### DIFF
--- a/graphics/djvulibre/Portfile
+++ b/graphics/djvulibre/Portfile
@@ -31,8 +31,9 @@ depends_lib         port:libiconv \
                     port:jpeg \
                     port:tiff
 
-depends_build       port:librsvg
-license_noconflict  librsvg
+# Remove librsvg dependency, not needed with --disable-desktopfiles (below)
+# depends_build       port:librsvg
+# license_noconflict  librsvg
 
 # Teach glibtool about -stdlib=libc++
 use_autoreconf  yes


### PR DESCRIPTION
Remove unused librsvg dependency.
Closes https://trac.macports.org/ticket/61837

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.14.6 build 18G6032
Xcode 11.5 build 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->