### PR TITLE
opencoarrays: fix MPI linkage

### DIFF
--- a/science/OpenCoarrays/Portfile
+++ b/science/OpenCoarrays/Portfile
@@ -7,7 +7,7 @@ PortGroup           mpi 1.0
 
 github.setup        sourceryinstitute OpenCoarrays 2.9.2
 github.tarball_from releases
-revision            1
+revision            2
 categories          science parallel devel
 platforms           darwin
 license             BSD
@@ -22,9 +22,8 @@ long_description    OpenCoarrays is an open-source software project \
                     since the GCC 5.1.0 release.
 homepage            http://www.opencoarrays.org
 
-mpi.setup           require require_fortran \
-                    -gcc44 -gcc45 -gcc46 -gcc47 -gcc48 -gcc49 -gcc5 \
-                    -clang -fortran
+mpi.setup           require require_fortran
+
 universal_variant   no
 
 checksums           rmd160  d0cf1f270b5d17b239825b8720dcacba1d6b6057 \
@@ -35,17 +34,9 @@ checksums           rmd160  d0cf1f270b5d17b239825b8720dcacba1d6b6057 \
 
 cmake.out_of_source yes
 
-post-patch {
-    reinplace "s|mpicc|${prefix}/bin/mpicc-${mpi.name}|g" \
-        src/tests/unit/simple/CMakeLists.txt
-}
-
-# Required to run the test phase.
 pre-configure {
     configure.args-append \
-        -DMPIEXEC=${prefix}/bin/${mpi.exec} \
-        -DMPI_C_COMPILER=${prefix}/bin/mpicc-${mpi.name} \
-        -DMPI_Fortran_COMPILER=${prefix}/bin/mpif90-${mpi.name}
+        -DCMAKE_PREFIX_PATH=${prefix}/bin
 }
 
 test.run            yes


### PR DESCRIPTION
Update and simplify linkage to MPI components.
Remove obsolete methods.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
