### PR TITLE
vigra: update to 1.11.2

### DIFF
--- a/graphics/vigra/Portfile
+++ b/graphics/vigra/Portfile
@@ -8,9 +8,9 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           boost 1.0
 
-github.setup        ukoethe vigra 1-11-1 Version-
+github.setup        ukoethe vigra 1-11-2 Version-
 version             [strsed ${github.version} {g/-/./}]
-revision            20
+revision            0
 categories          graphics
 platforms           darwin
 license             MIT
@@ -25,9 +25,9 @@ long_description    VIGRA stands for \"Vision with Generic Algorithms\". \
                     application, without thereby giving up execution speed.
 homepage            https://ukoethe.github.io/vigra/
 
-checksums           rmd160  21378c72a0702cbdd4de4d79c59f0587f6bcde8d \
-                    sha256  b0cdf67e283d2b52e35a45cdcff44453b5b73a9b7d7a1ca84d6508107e49832f \
-                    size    34212258
+checksums           rmd160  4d65d9618271ca7293227ec44333a792759525f5 \
+                    sha256  8fb06a3c35ee58ab28eeda990a124ab15ae124a46c2084dd2c8180cdc0ba3cf0 \
+                    size    34212707
 
 depends_lib         path:include/turbojpeg.h:libjpeg-turbo \
                     port:tiff \
@@ -45,22 +45,6 @@ configure.args-append \
                     -DOPENEXR_IEX_LIBRARY=${prefix}/libexec/openexr2/lib/libIex.dylib \
                     -DOPENEXR_ILMTHREAD_LIBRARY=${prefix}/libexec/openexr2/lib/libIlmThread.dylib \
                     -DOPENEXR_IMATH_LIBRARY=${prefix}/libexec/openexr2/lib/libImath.dylib
-
-# modify tests for existence of c++11 std::unique_ptr
-# see https://github.com/ukoethe/vigra/pull/421
-patchfiles-append   patch-uniq_ptr.diff
-
-# see https://trac.macports.org/ticket/54548
-patchfiles-append   patch-template.diff
-
-# see https://github.com/ukoethe/vigra/pull/451/commits/a6fa62663c6a6b752ed0707e95f643e25867a0f9
-patchfiles-append   patch-python.diff
-
-# allow cmake to find MacPorts boost_python library
-patchfiles-append   patch-boost_python.diff
-
-# see https://trac.macports.org/ticket/59970
-patchfiles-append   patch-sifImport.diff
 
 post-patch {
     reinplace "s|@DOCDIR@|${prefix}/share/doc/${name}|g" ${worksrcpath}/config/vigra-config.in
@@ -143,8 +127,3 @@ if { ${active_py} eq "" } {
     set active_py_nodot [string map {. {}} ${active_py}]
     default_variants +python${active_py_nodot}
 }
-
-livecheck.version   ${version}
-livecheck.type      regex
-livecheck.url       ${homepage}
-livecheck.regex     {>version ([0-9.]+)<}


### PR DESCRIPTION
WIP.  More work needed.  Current problems:

* Dependency failure in Cmake configure.
* Port lint warnings, conflicts between python variants.

Current change log:

* Update vigra 1.11.1 --> 1.11.2.
* Remove patch-uniq_ptr.diff.  Was fixed upstream.
* Remove patch-template.diff.  Was fixed upstream.
* Remove patch-python.diff.  Was fixed upstream.
* Remove patch-boost_python.diff.  Was fixed upstream.
* Remove patch-sifImport.diff.  Was fixed upstream.
* Fix livecheck.

* May fix https://trac.macports.org/ticket/69007